### PR TITLE
fix: content-retrieval list items are not editable

### DIFF
--- a/src/main/resources/jnt_contentRetrieval/html/contentRetrieval.hidden.load.jsp
+++ b/src/main/resources/jnt_contentRetrieval/html/contentRetrieval.hidden.load.jsp
@@ -58,7 +58,7 @@
 <%-- <p>Debug > Nb of result from query (Criteria : ${criteria.string} - Nb of result : ${nbOfResult.long} - Mode : ${mode.string}) : ${fn:length(result.nodes)}</p>  --%>
 
 <%-- Set variables to store the result --%>
-<c:set target="${moduleMap}" property="editable" value="false" />
+<c:set target="${moduleMap}" property="editable" value="true" />
 <c:set target="${moduleMap}" property="listQuery" value="${listQuery}" />
 <c:set target="${moduleMap}" property="emptyListMessage">
    <c:choose>


### PR DESCRIPTION
## Summary
- `contentRetrieval.hidden.load.jsp` hardcoded `editable="false"` for its list items, so `ModuleTag` never emitted the `<div jahiatype="module">` wrapper needed for pageComposer/jContent to recognize them as editable at all.
- This has been the behavior since Jahia 6.5 — not a regression — but it's inconsistent with the standard `jnt:list`, which sets `editable="true"` in its own `list.hidden.load.jsp`.
- Flipping the flag aligns contentRetrieval with that default. Actual editability still goes through normal JCR permission checks and jContent's own editing rules — this only makes the items *recognizable* as editable modules.

## Test plan
- [ ] Add a content-retrieval component (e.g. for "News entry" or "rich-text") on a page
- [ ] Confirm list items are now clickable/editable in both pageComposer and jContent PageBuilder
- [ ] Confirm normal permission checks still apply (a user without edit rights still can't edit)

Fixes Jahia/jahia-private#5084